### PR TITLE
Add MedBot case study and clickable project cards

### DIFF
--- a/medbot.html
+++ b/medbot.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MedBot — Health Assistant Prototype</title>
+  <meta name="description" content="MedBot case study" />
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="noise"></div>
+  <header class="site-header">
+    <a class="brand" href="index.html#top"><span class="brand-dean">Dean</span> <span class="brand-last">Gudgeon</span></a>
+    <nav class="nav">
+      <a href="index.html#projects">Projects</a>
+      <a href="index.html#services">Services</a>
+      <a href="index.html#about">About</a>
+      <a href="index.html#contact" class="pill">Contact</a>
+      <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
+    </nav>
+  </header>
+
+  <main id="top">
+    <section class="section" style="max-width:980px;">
+      <h1>MedBot — Health Assistant Prototype</h1>
+      <p class="sub">Chat interface for safe Q&amp;A and triage‑style guidance. Built to run quickly on RunPod with guardrails and human‑handoff paths.</p>
+    </section>
+
+    <section class="section" style="max-width:980px;">
+      <article class="card" style="padding:0; overflow:hidden;">
+        <img src="assets/medbot-thumb.jpg" alt="MedBot screenshot" style="display:block; width:100%; height:auto; border-radius:inherit;">
+      </article>
+    </section>
+
+    <section class="section" style="max-width:980px;">
+      <div class="grid">
+        <article class="card">
+          <h3>What it does</h3>
+          <ul>
+            <li>Greets users and collects basic intent safely.</li>
+            <li>Routes to information, forms, or human follow-up.</li>
+            <li>Keeps tone consistent; logs transcripts for review.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Tech stack</h3>
+          <ul>
+            <li>RunPod + LLM API</li>
+            <li>Guardrails &amp; prompt templates</li>
+            <li>Optional: Telegram / Web widget</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" style="max-width:980px;">
+      <article class="card">
+        <h3>Outcome</h3>
+        <p>Faster responses for common questions, better data capture for follow-ups, and a foundation for automation. Built with a “start small, ship fast” approach.</p>
+      </article>
+    </section>
+
+    <section class="section" style="max-width:980px; text-align:center;">
+      <a class="btn primary" href="mailto:youremail@example.com?subject=MedBot%20%E2%80%94%20Let%27s%20talk">Talk about MedBot</a>
+      <a class="btn ghost" href="index.html#projects">Back to projects</a>
+    </section>
+  </main>
+
+  <footer class="site-footer"><p>© 2025 Dean · Self‑taught AI innovator · West Sussex</p></footer>
+  <script src="theme.js"></script>
+</body>
+</html>

--- a/projects.js
+++ b/projects.js
@@ -1,23 +1,22 @@
 const projects = [
   { title: "MedBot — Health Assistant Prototype",
     desc: "Chatbot demo built on RunPod for safe Q&A and triage-style guidance while users wait for appointments.",
-    stack: "RunPod · LLM API · JavaScript", image: "assets/medbot-thumb.jpg", link: "#" },
+    stack: "RunPod · LLM API · JavaScript", image: "assets/medbot-thumb.jpg", link: "medbot.html" },
   { title: "Email Triage Automation",
     desc: "n8n workflow that classifies incoming emails, tags them, and drafts suggested replies to speed up responses.",
-    stack: "n8n · LLM · Gmail API (or IMAP)", image: "assets/email-thumb.jpg", link: "#" },
+    stack: "n8n · LLM · Gmail API (or IMAP)", image: "assets/email-thumb.jpg", link: "email-triage.html" },
   { title: "SamarAI — NHS Innovation Support",
     desc: "Mental-health journaling tool supported by the NHS innovation system (NIHR & RSS).",
-    stack: "Python · LLM · Product Design", image: "assets/samarai-thumb.jpg", link: "#" }
+    stack: "Python · LLM · Product Design", image: "assets/samarai-thumb.jpg", link: "samarai.html" }
 ];
 function renderProjects(){
   const grid = document.getElementById('project-grid');
   grid.innerHTML = projects.map(p => `
-    <article class="card project-card">
+    <a class="card project-card card-link" href="${p.link || '#'}">
       <img src="${p.image}" alt="${p.title} preview">
       <h3>${p.title}</h3>
       <p>${p.desc}</p>
       <div class="stack">${p.stack}</div>
-      ${p.link && p.link !== "#" ? `<a class="more" href="${p.link}" target="_blank" rel="noopener">View</a>` : ""}
-    </article>`).join("");
+    </a>`).join("");
 }
 document.addEventListener('DOMContentLoaded', renderProjects);

--- a/style.css
+++ b/style.css
@@ -65,6 +65,9 @@ h1 .accent { background: linear-gradient(90deg, var(--accent), var(--accent-2));
 .project-card .stack { font-size: 13px; color: var(--muted); }
 .project-card a.more { display: inline-block; margin-top: 6px; font-weight: 600; color: var(--accent); text-decoration: none; }
 
+.card-link { text-decoration: none; color: inherit; display: block; }
+.card-link:hover { border-color: rgba(154,134,255,.5); transform: translateY(-2px); }
+
 .about { background: var(--panel); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .about-wrap { max-width: 820px; margin: 0 auto; }
 .about-card { background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 24px; line-height: 1.6; }
@@ -84,5 +87,5 @@ h1 .accent { background: linear-gradient(90deg, var(--accent), var(--accent-2));
 }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { transition: none !important; animation: none !important; }
-  .card:hover, .btn:hover { transform: none; box-shadow: none; }
+  .card:hover, .btn:hover, .card-link:hover { transform: none; box-shadow: none; }
 }


### PR DESCRIPTION
## Summary
- Render project tiles as full-card links to detail pages
- Include new MedBot case study page using updated thumbnail
- Add card-link styles and reduced-motion safeguard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aab1be6d208325ba6569231e58853b