### PR TITLE
Fix mobile nav overlay for small screens

### DIFF
--- a/404.html
+++ b/404.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section contact">

--- a/about.html
+++ b/about.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/contact.html
+++ b/contact.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/email-triage.html
+++ b/email-triage.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/index.html
+++ b/index.html
@@ -23,14 +23,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="hero">

--- a/medbot.html
+++ b/medbot.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/samarai.html
+++ b/samarai.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/services.html
+++ b/services.html
@@ -22,14 +22,15 @@
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="index.html">Dean Gudgeon<span class="brand-dot"></span></a>
-    <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="site-nav">☰</button>
-    <nav id="site-nav" class="nav">
+    <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
+    <nav id="navMenu" class="nav">
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="about.html">About</a>
       <a href="contact.html" class="pill">Contact</a>
       <button id="themeToggle" class="toggle" aria-label="Toggle theme">☾</button>
     </nav>
+    <div class="nav-overlay"></div>
   </header>
   <main id="content">
     <section class="section">

--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@ html[data-theme='light'] .site-header{background:rgba(247,247,248,.86)}
 .brand-dot{width:10px;height:10px;border-radius:50%;background:linear-gradient(90deg,var(--accent),var(--accent-2));margin-left:6px}
 .menu-toggle{display:none;background:none;border:1px solid var(--line);border-radius:8px;padding:6px 8px;color:var(--text)}
 .nav{display:flex;align-items:center;gap:16px}
+.nav-overlay{display:none}
 .nav a{text-decoration:none;opacity:.9}
 .nav .pill{border:1px solid var(--line);padding:6px 12px;border-radius:999px}
 .toggle{width:40px;height:24px;border:1px solid var(--line);border-radius:12px;background:var(--panel);cursor:pointer;font-size:0;color:transparent;position:relative}
@@ -65,10 +66,14 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
 .contact{text-align:center}
 .site-footer{text-align:center;padding:30px 20px;color:var(--muted);border-top:1px solid var(--line);display:flex;flex-direction:column;gap:12px}
 .footer-nav{display:flex;justify-content:center;gap:16px;flex-wrap:wrap}
-@media (max-width:768px){
-  .menu-toggle{display:block}
-  .nav{display:none;flex-direction:column;align-items:flex-start;width:100%;margin-top:10px}
-  .nav.open{display:flex}
+@media (max-width:900px){
+  #navToggle{display:block}
+  #navMenu{position:fixed;top:60px;left:0;right:0;bottom:0;background:rgba(12,11,19,.92);backdrop-filter:blur(10px);display:flex;flex-direction:column;align-items:flex-start;gap:16px;padding:20px;transform:translateY(-100%);transition:transform .3s ease;overflow:auto;z-index:100}
+  body.nav-open #navMenu{transform:translateY(0)}
+  .nav-overlay{display:block;position:fixed;inset:0;background:rgba(0,0,0,.6);backdrop-filter:blur(2px);opacity:0;visibility:hidden;transition:opacity .3s ease;z-index:99}
+  body.nav-open .nav-overlay{opacity:1;visibility:visible}
+  body.nav-open{overflow:hidden}
+  .site-header .brand,.site-header #navToggle{position:relative;z-index:101}
 }
 @media (prefers-reduced-motion:reduce){
   *,*::before,*::after{transition:none!important;animation:none!important}

--- a/theme.js
+++ b/theme.js
@@ -16,13 +16,20 @@
   }
   const year=document.getElementById('year');
   if(year) year.textContent=new Date().getFullYear();
-  const menu=document.getElementById('menuToggle');
-  const nav=document.getElementById('site-nav');
-  if(menu && nav){
-    menu.addEventListener('click',()=>{
-      const expanded=menu.getAttribute('aria-expanded')==='true';
-      menu.setAttribute('aria-expanded',!expanded);
-      nav.classList.toggle('open');
+  const toggle=document.getElementById('navToggle');
+  const nav=document.getElementById('navMenu');
+  const overlay=document.querySelector('.nav-overlay');
+  const close=()=>{
+    document.body.classList.remove('nav-open');
+    if(toggle) toggle.setAttribute('aria-expanded','false');
+  };
+  if(toggle && nav){
+    toggle.addEventListener('click',()=>{
+      const open=document.body.classList.toggle('nav-open');
+      toggle.setAttribute('aria-expanded',open);
     });
+    overlay&&overlay.addEventListener('click',close);
+    nav.addEventListener('click',e=>{if(e.target.tagName==='A') close();});
+    document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
   }
 })();


### PR DESCRIPTION
## Summary
- prevent mobile nav overlap by converting menu to fixed panel with overlay
- toggle body `nav-open` class to lock scroll and update button aria attributes
- close nav on overlay click, link click, or ESC key

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75744a008325adbca4437cf0551d