### PR TITLE
feat(bg): subtle lit-squares animated background (code-only)

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/about.html
+++ b/about.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/addons.html
+++ b/addons.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/contact.html
+++ b/contact.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/email-triage.html
+++ b/email-triage.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/medbot.html
+++ b/medbot.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/samarai.html
+++ b/samarai.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/services.html
+++ b/services.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">

--- a/style.css
+++ b/style.css
@@ -81,3 +81,19 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
 }
 
 .faq dt{font-weight:600;margin-top:12px}.faq dd{margin:4px 0 8px 0}
+
+:root{
+  --accent: #a78bfa;
+}
+
+#bg-squares{
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: #0b0b10;
+}
+
+@media (prefers-reduced-motion: reduce){
+  #bg-squares{ display:none; }
+}

--- a/theme.js
+++ b/theme.js
@@ -33,3 +33,75 @@
     document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
   }
 })();
+
+(function(){
+  const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const canvas = document.getElementById('bg-squares');
+  if (!canvas || mql.matches) return;
+
+  const ctx = canvas.getContext('2d');
+  const ACCENT = getComputedStyle(document.documentElement)
+                  .getPropertyValue('--accent').trim() || '#a78bfa';
+
+  let w, h, dpr, cols, rows, size, gap;
+  const cells = [];
+
+  function resize(){
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    w = canvas.width  = Math.floor(innerWidth  * dpr);
+    h = canvas.height = Math.floor(innerHeight * dpr);
+    canvas.style.width  = innerWidth + 'px';
+    canvas.style.height = innerHeight + 'px';
+
+    size = 20 * dpr;
+    gap  = 10 * dpr;
+    cols = Math.ceil(w / (size + gap));
+    rows = Math.ceil(h / (size + gap));
+
+    cells.length = 0;
+    for (let y = 0; y < rows; y++){
+      for (let x = 0; x < cols; x++){
+        cells.push({ x, y, a: 0, t: Math.random() * 2000 });
+      }
+    }
+  }
+
+  function hexToRgba(hex, a){
+    const h = hex.replace('#','');
+    const full = h.length === 3 ? h.split('').map(c => c+c).join('') : h;
+    const n = parseInt(full, 16);
+    const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+    return `rgba(${r},${g},${b},${a})`;
+  }
+
+  function frame(t){
+    ctx.clearRect(0,0,w,h);
+
+    for (const c of cells){
+      const pulse = (Math.sin((t + c.t)/1000 + (c.x*13 + c.y*7)) + 1) * 0.5;
+      c.a = c.a * 0.90 + pulse * 0.10;
+
+      if (c.a > 0.05){
+        const X = Math.floor(c.x * (size + gap));
+        const Y = Math.floor(c.y * (size + gap));
+        const S = size * 0.6;
+        ctx.fillStyle = hexToRgba(ACCENT, 0.15 * c.a);
+        ctx.fillRect(X, Y, S, S);
+      }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  window.addEventListener('resize', resize, { passive: true });
+  resize();
+  requestAnimationFrame(frame);
+
+  try {
+    mql.addEventListener?.('change', e => {
+      if (e.matches) {
+        ctx.clearRect(0,0,w,h);
+        canvas.remove();
+      }
+    });
+  } catch(_) {}
+})();


### PR DESCRIPTION
## Summary
- add global fixed canvas for animated lit-square backdrop
- style and script for subtle, responsive squares respecting reduced-motion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4bf28888325a465236544b4ec3f