### PR TITLE
feat(site): scoped animated grid for hero, restore full-width tech scroller, refresh FAQ, nav polish

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/about.html
+++ b/about.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/addons.html
+++ b/addons.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/contact.html
+++ b/contact.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>
@@ -60,18 +58,20 @@
         </form>
       </div>
     </section>
-    <section class="section">
-      <div class="container">
-        <h2>FAQ</h2>
-        <dl class="faq">
-          <dt>How long does it take?</dt>
-          <dd>Most starter projects ship in about a week.</dd>
-          <dt>What does it cost?</dt>
-          <dd>Starter work begins around £X; custom quotes available.</dd>
-          <dt>Do I need technical knowledge?</dt>
-          <dd>No—I'll guide you through setup and handover.</dd>
-        </dl>
-      </div>
+    <section id="faq" class="faq container">
+      <h2>FAQ</h2>
+
+      <h3>How long does it take?</h3>
+      <p>Starter projects usually ship within a week. Pilots with data integrations can take 2–4 weeks.</p>
+
+      <h3>What does it cost?</h3>
+      <p>Starter work begins around £X. Most pilots land between £X–£Y depending on scope and integrations.</p>
+
+      <h3>Do I need to be technical?</h3>
+      <p>Nope. I set things up, hand over with a short walkthrough, and you can message me if you get stuck.</p>
+
+      <h3>What tools do you use?</h3>
+      <p>Whatever fits the job: n8n/Zapier for glue, RunPod for GPU jobs, Telegram/Email for interfaces, LLMs for brains.</p>
     </section>
   </main>
   <footer class="site-footer">

--- a/email-triage.html
+++ b/email-triage.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/index.html
+++ b/index.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>
@@ -37,7 +35,8 @@
     <div class="nav-overlay"></div>
   </header>
   <main id="content">
-    <section class="hero">
+    <section id="hero" class="hero has-grid">
+      <canvas id="heroGrid" class="grid-canvas" aria-hidden="true"></canvas>
       <div class="glow"></div>
       <div class="container">
         <h1><span class="accent">AI that works</span> in the real world.</h1>
@@ -53,9 +52,24 @@
         </div>
       </div>
     </section>
-    <section class="logos">
-      <div class="marquee">
-        <span>n8n</span><span>RunPod</span><span>Zapier</span><span>Telegram</span><span>WhatsApp</span><span>GitHub</span><span>OpenRouter</span><span>Vercel</span><span>Cloudflare</span>
+    <section class="tech-marquee" aria-label="Tools I use">
+      <div class="track">
+        <span class="chip">RunPod</span>
+        <span class="chip">n8n</span>
+        <span class="chip">Zapier</span>
+        <span class="chip">Telegram</span>
+        <span class="chip">Vercel</span>
+        <span class="chip">Cloudflare</span>
+        <span class="chip">LLaMA</span>
+        <span class="chip">GitHub</span>
+        <span class="chip">RunPod</span>
+        <span class="chip">n8n</span>
+        <span class="chip">Zapier</span>
+        <span class="chip">Telegram</span>
+        <span class="chip">Vercel</span>
+        <span class="chip">Cloudflare</span>
+        <span class="chip">LLaMA</span>
+        <span class="chip">GitHub</span>
       </div>
     </section>
     <section id="projects" class="section">
@@ -63,6 +77,21 @@
         <h2>Projects</h2>
         <div id="project-grid" class="grid"></div>
       </div>
+    </section>
+    <section id="faq" class="faq container">
+      <h2>FAQ</h2>
+
+      <h3>How long does it take?</h3>
+      <p>Starter projects usually ship within a week. Pilots with data integrations can take 2–4 weeks.</p>
+
+      <h3>What does it cost?</h3>
+      <p>Starter work begins around £X. Most pilots land between £X–£Y depending on scope and integrations.</p>
+
+      <h3>Do I need to be technical?</h3>
+      <p>Nope. I set things up, hand over with a short walkthrough, and you can message me if you get stuck.</p>
+
+      <h3>What tools do you use?</h3>
+      <p>Whatever fits the job: n8n/Zapier for glue, RunPod for GPU jobs, Telegram/Email for interfaces, LLMs for brains.</p>
     </section>
     <section id="contact" class="section contact">
       <div class="container">
@@ -87,11 +116,5 @@
   </footer>
   <script src="projects.js"></script>
   <script src="theme.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded',()=>{
-      const marquee=document.querySelector('.marquee');
-      if(marquee) marquee.innerHTML+=marquee.innerHTML;
-    });
-  </script>
 </body>
 </html>

--- a/medbot.html
+++ b/medbot.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/privacy.html
+++ b/privacy.html
@@ -25,7 +25,6 @@
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/samarai.html
+++ b/samarai.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/services.html
+++ b/services.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ a{color:inherit}
 .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden}
 .skip-link:focus{left:10px;top:10px;width:auto;height:auto;padding:8px 12px;background:var(--accent);color:#fff;z-index:999;border-radius:4px}
 .noise{pointer-events:none;position:fixed;inset:0;opacity:.06;mix-blend-mode:overlay;background:repeating-linear-gradient(45deg,rgba(0,0,0,.2)0,rgba(0,0,0,.2)1px,transparent 1px,transparent 2px)}
-.site-header{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:14px 20px;background:rgba(12,11,19,.72);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+.site-header{position:sticky;top:0;z-index:50;display:flex;align-items:center;justify-content:space-between;padding:14px 20px;background:rgba(12,11,19,.72);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
 html[data-theme='light'] .site-header{background:rgba(247,247,248,.86)}
 .brand{font-weight:800;letter-spacing:.3px;text-decoration:none;color:var(--text);font-size:28px;display:flex;align-items:center}
 .dot{width:10px;height:10px;border-radius:50%;background:linear-gradient(90deg,var(--accent),var(--accent-2));margin-left:6px}
@@ -26,7 +26,12 @@ html[data-theme='light'] .site-header{background:rgba(247,247,248,.86)}
 .toggle{width:40px;height:24px;border:1px solid var(--line);border-radius:12px;background:var(--panel);cursor:pointer;font-size:0;color:transparent;position:relative}
 .toggle::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:var(--text);transition:transform .2s ease}
 html[data-theme='light'] .toggle::after{transform:translateX(18px)}
+body.nav-open .site-header+main{margin-top:var(--nav-open-offset,3.5rem)}
 .hero{position:relative;padding:120px 0 80px;overflow:hidden;border-bottom:1px solid var(--line);text-align:center}
+.hero.has-grid{position:relative;overflow:hidden}
+.grid-canvas{position:absolute;inset:0;z-index:0;pointer-events:none;opacity:.8;filter:saturate(120%)}
+.hero.has-grid>*:not(.grid-canvas){position:relative;z-index:1}
+.hero.has-grid::after{content:"";position:absolute;inset:-10%;background:radial-gradient(120% 80% at 50% 40%,transparent 60%,rgba(0,0,0,.5) 100%);z-index:1;pointer-events:none}
 .hero .glow{position:absolute;inset:-30% -10% auto -10%;height:65%;background:radial-gradient(60% 60% at 50% 10%,rgba(154,134,255,.6),transparent 70%);filter:blur(90px)}
 .hero h1{font-size:clamp(34px,6vw,64px);line-height:1.08;margin:0 20px 14px}
 .hero .sub{max-width:800px;margin:0 auto 32px;color:var(--muted);font-size:clamp(1rem,2.5vw,1.25rem)}
@@ -38,13 +43,23 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
 .btn.outline{color:var(--accent);border-color:var(--accent);background:transparent}
 .btn:hover{transform:translateY(-2px);box-shadow:0 6px 20px rgba(0,0,0,.3)}
 .btn:active{transform:scale(.98);box-shadow:none}
-.chip{display:inline-block;padding:4px 8px;border:1px solid var(--line);border-radius:999px;font-size:12px;margin-right:4px;margin-top:4px}
+.chip{display:inline-block;padding:.4rem .75rem;border-radius:999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.09);font-size:.95rem;line-height:1;letter-spacing:.2px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)}
 .badges{display:flex;gap:10px;justify-content:center;margin-top:16px;flex-wrap:wrap}
 .badge{font-size:12px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;opacity:.9}
-.logos{padding:18px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line);background:rgba(255,255,255,0.02);overflow:hidden}
-.marquee{display:flex;gap:50px;animation:scroll 22s linear infinite;padding:8px 0;opacity:.7;width:max-content}
-.marquee span{font-weight:600;white-space:nowrap}
-@keyframes scroll{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+.tech-marquee{
+  width:100vw;margin-inline:50%;transform:translateX(-50%);
+  overflow:hidden;border-top:1px solid rgba(255,255,255,.06);
+  border-bottom:1px solid rgba(255,255,255,.06);
+  mask-image:linear-gradient(90deg,transparent,#000 8%,#000 92%,transparent);
+}
+.tech-marquee .track{
+  display:inline-flex;gap:.75rem;padding:.8rem 1rem;
+  white-space:nowrap;animation:marquee 22s linear infinite;
+}
+@keyframes marquee{
+  from{transform:translateX(0);}
+  to{transform:translateX(-50%);}
+}
 .section{padding:72px 20px}
 .container{max-width:1200px;margin:0 auto}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px}
@@ -80,20 +95,5 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
   .card:hover,.btn:hover,.card-link:hover{transform:none;box-shadow:none}
 }
 
-.faq dt{font-weight:600;margin-top:12px}.faq dd{margin:4px 0 8px 0}
+.faq h2{margin-bottom:1rem}.faq h3{margin-top:1.25rem;margin-bottom:.35rem;font-size:1.15rem}.faq p{opacity:.9}
 
-:root{
-  --accent: #a78bfa;
-}
-
-#bg-squares{
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background: #0b0b10;
-}
-
-@media (prefers-reduced-motion: reduce){
-  #bg-squares{ display:none; }
-}


### PR DESCRIPTION
## Summary
- scope animated grid canvas to hero and remove global background
- add full-width tech marquee and refresh FAQ copy
- polish navigation to avoid overlap and drop redundant Home link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbec1cd348325a8ed8932ca222d62