### PR TITLE
Remove laggy hero background; add footer-only pings (CSS-only)

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/about.html
+++ b/about.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/addons.html
+++ b/addons.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/contact.html
+++ b/contact.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>
@@ -60,18 +58,20 @@
         </form>
       </div>
     </section>
-    <section class="section">
-      <div class="container">
-        <h2>FAQ</h2>
-        <dl class="faq">
-          <dt>How long does it take?</dt>
-          <dd>Most starter projects ship in about a week.</dd>
-          <dt>What does it cost?</dt>
-          <dd>Starter work begins around £X; custom quotes available.</dd>
-          <dt>Do I need technical knowledge?</dt>
-          <dd>No—I'll guide you through setup and handover.</dd>
-        </dl>
-      </div>
+    <section id="faq" class="faq container">
+      <h2>FAQ</h2>
+
+      <h3>How long does it take?</h3>
+      <p>Starter projects usually ship within a week. Pilots with data integrations can take 2–4 weeks.</p>
+
+      <h3>What does it cost?</h3>
+      <p>Starter work begins around £X. Most pilots land between £X–£Y depending on scope and integrations.</p>
+
+      <h3>Do I need to be technical?</h3>
+      <p>Nope. I set things up, hand over with a short walkthrough, and you can message me if you get stuck.</p>
+
+      <h3>What tools do you use?</h3>
+      <p>Whatever fits the job: n8n/Zapier for glue, RunPod for GPU jobs, Telegram/Email for interfaces, LLMs for brains.</p>
     </section>
   </main>
   <footer class="site-footer">

--- a/email-triage.html
+++ b/email-triage.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/index.html
+++ b/index.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>
@@ -37,7 +35,7 @@
     <div class="nav-overlay"></div>
   </header>
   <main id="content">
-    <section class="hero">
+    <section id="hero" class="hero">
       <div class="glow"></div>
       <div class="container">
         <h1><span class="accent">AI that works</span> in the real world.</h1>
@@ -53,9 +51,24 @@
         </div>
       </div>
     </section>
-    <section class="logos">
-      <div class="marquee">
-        <span>n8n</span><span>RunPod</span><span>Zapier</span><span>Telegram</span><span>WhatsApp</span><span>GitHub</span><span>OpenRouter</span><span>Vercel</span><span>Cloudflare</span>
+    <section class="tech-marquee" aria-label="Tools I use">
+      <div class="track">
+        <span class="chip">RunPod</span>
+        <span class="chip">n8n</span>
+        <span class="chip">Zapier</span>
+        <span class="chip">Telegram</span>
+        <span class="chip">Vercel</span>
+        <span class="chip">Cloudflare</span>
+        <span class="chip">LLaMA</span>
+        <span class="chip">GitHub</span>
+        <span class="chip">RunPod</span>
+        <span class="chip">n8n</span>
+        <span class="chip">Zapier</span>
+        <span class="chip">Telegram</span>
+        <span class="chip">Vercel</span>
+        <span class="chip">Cloudflare</span>
+        <span class="chip">LLaMA</span>
+        <span class="chip">GitHub</span>
       </div>
     </section>
     <section id="projects" class="section">
@@ -63,6 +76,21 @@
         <h2>Projects</h2>
         <div id="project-grid" class="grid"></div>
       </div>
+    </section>
+    <section id="faq" class="faq container">
+      <h2>FAQ</h2>
+
+      <h3>How long does it take?</h3>
+      <p>Starter projects usually ship within a week. Pilots with data integrations can take 2–4 weeks.</p>
+
+      <h3>What does it cost?</h3>
+      <p>Starter work begins around £X. Most pilots land between £X–£Y depending on scope and integrations.</p>
+
+      <h3>Do I need to be technical?</h3>
+      <p>Nope. I set things up, hand over with a short walkthrough, and you can message me if you get stuck.</p>
+
+      <h3>What tools do you use?</h3>
+      <p>Whatever fits the job: n8n/Zapier for glue, RunPod for GPU jobs, Telegram/Email for interfaces, LLMs for brains.</p>
     </section>
     <section id="contact" class="section contact">
       <div class="container">
@@ -87,11 +115,5 @@
   </footer>
   <script src="projects.js"></script>
   <script src="theme.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded',()=>{
-      const marquee=document.querySelector('.marquee');
-      if(marquee) marquee.innerHTML+=marquee.innerHTML;
-    });
-  </script>
 </body>
 </html>

--- a/medbot.html
+++ b/medbot.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/privacy.html
+++ b/privacy.html
@@ -25,7 +25,6 @@
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/samarai.html
+++ b/samarai.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/services.html
+++ b/services.html
@@ -19,14 +19,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <canvas id="bg-squares" aria-hidden="true"></canvas>
   <div class="noise" aria-hidden="true"></div>
   <a href="#content" class="skip-link">Skip to content</a>
   <header class="site-header">
     <a class="brand" href="/">Dean Gudgeon<span class="dot"></span></a>
     <button id="navToggle" class="menu-toggle" aria-controls="navMenu" aria-expanded="false">☰</button>
     <nav id="navMenu" class="nav">
-      <a href="index.html">Home</a>
       <a href="index.html#projects">Projects</a>
       <a href="services.html">Services</a>
       <a href="addons.html">Add-ons</a>

--- a/style.css
+++ b/style.css
@@ -1,20 +1,26 @@
 *,*::before,*::after{box-sizing:border-box}
 a:focus-visible,button:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 :root{
-  --bg:#0b0b12;--panel:#12111a;--text:#ece9ff;--muted:#a39ec0;--line:#242136;
+  --bg:#0e0e12;--panel:#12111a;--text:#ece9ff;--muted:#a39ec0;--line:#242136;
   --accent:#9a86ff;--accent-2:#6b56e8;--card:rgba(255,255,255,0.04);--radius:16px
 }
 html[data-theme='light']{
   --bg:#f7f7f9;--panel:#ffffff;--text:#111019;--muted:#64607a;--line:#e8e6f2;
   --accent:#6a4fb3;--accent-2:#4a35a1;--card:#ffffff
 }
-html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;overflow-x:hidden}
+html,body{margin:0;padding:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;overflow-x:hidden;color:var(--text)}
+body{
+  background:
+    radial-gradient(1200px 600px at 50% 0%,rgba(167,139,250,.12),transparent 60%),
+    #0e0e12;
+  will-change:auto;
+}
 img{max-width:100%;display:block}
 a{color:inherit}
 .skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden}
 .skip-link:focus{left:10px;top:10px;width:auto;height:auto;padding:8px 12px;background:var(--accent);color:#fff;z-index:999;border-radius:4px}
 .noise{pointer-events:none;position:fixed;inset:0;opacity:.06;mix-blend-mode:overlay;background:repeating-linear-gradient(45deg,rgba(0,0,0,.2)0,rgba(0,0,0,.2)1px,transparent 1px,transparent 2px)}
-.site-header{position:sticky;top:0;z-index:100;display:flex;align-items:center;justify-content:space-between;padding:14px 20px;background:rgba(12,11,19,.72);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
+.site-header{position:sticky;top:0;z-index:50;display:flex;align-items:center;justify-content:space-between;padding:14px 20px;background:rgba(12,11,19,.72);backdrop-filter:blur(10px);border-bottom:1px solid var(--line)}
 html[data-theme='light'] .site-header{background:rgba(247,247,248,.86)}
 .brand{font-weight:800;letter-spacing:.3px;text-decoration:none;color:var(--text);font-size:28px;display:flex;align-items:center}
 .dot{width:10px;height:10px;border-radius:50%;background:linear-gradient(90deg,var(--accent),var(--accent-2));margin-left:6px}
@@ -26,6 +32,7 @@ html[data-theme='light'] .site-header{background:rgba(247,247,248,.86)}
 .toggle{width:40px;height:24px;border:1px solid var(--line);border-radius:12px;background:var(--panel);cursor:pointer;font-size:0;color:transparent;position:relative}
 .toggle::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;border-radius:50%;background:var(--text);transition:transform .2s ease}
 html[data-theme='light'] .toggle::after{transform:translateX(18px)}
+body.nav-open .site-header+main{margin-top:var(--nav-open-offset,3.5rem)}
 .hero{position:relative;padding:120px 0 80px;overflow:hidden;border-bottom:1px solid var(--line);text-align:center}
 .hero .glow{position:absolute;inset:-30% -10% auto -10%;height:65%;background:radial-gradient(60% 60% at 50% 10%,rgba(154,134,255,.6),transparent 70%);filter:blur(90px)}
 .hero h1{font-size:clamp(34px,6vw,64px);line-height:1.08;margin:0 20px 14px}
@@ -38,13 +45,23 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
 .btn.outline{color:var(--accent);border-color:var(--accent);background:transparent}
 .btn:hover{transform:translateY(-2px);box-shadow:0 6px 20px rgba(0,0,0,.3)}
 .btn:active{transform:scale(.98);box-shadow:none}
-.chip{display:inline-block;padding:4px 8px;border:1px solid var(--line);border-radius:999px;font-size:12px;margin-right:4px;margin-top:4px}
+.chip{display:inline-block;padding:.4rem .75rem;border-radius:999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.09);font-size:.95rem;line-height:1;letter-spacing:.2px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)}
 .badges{display:flex;gap:10px;justify-content:center;margin-top:16px;flex-wrap:wrap}
 .badge{font-size:12px;padding:6px 10px;border:1px solid var(--line);border-radius:999px;opacity:.9}
-.logos{padding:18px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line);background:rgba(255,255,255,0.02);overflow:hidden}
-.marquee{display:flex;gap:50px;animation:scroll 22s linear infinite;padding:8px 0;opacity:.7;width:max-content}
-.marquee span{font-weight:600;white-space:nowrap}
-@keyframes scroll{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+.tech-marquee{
+  width:100vw;margin-inline:50%;transform:translateX(-50%);
+  overflow:hidden;border-top:1px solid rgba(255,255,255,.06);
+  border-bottom:1px solid rgba(255,255,255,.06);
+  mask-image:linear-gradient(90deg,transparent,#000 8%,#000 92%,transparent);
+}
+.tech-marquee .track{
+  display:inline-flex;gap:.75rem;padding:.8rem 1rem;
+  white-space:nowrap;animation:marquee 22s linear infinite;
+}
+@keyframes marquee{
+  from{transform:translateX(0);}
+  to{transform:translateX(-50%);}
+}
 .section{padding:72px 20px}
 .container{max-width:1200px;margin:0 auto}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px}
@@ -64,8 +81,30 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
 .gallery{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
 .gallery .project-thumb{height:160px}
 .contact{text-align:center}
-.site-footer{text-align:center;padding:30px 20px;color:var(--muted);border-top:1px solid var(--line);display:flex;flex-direction:column;gap:12px}
+.site-footer{text-align:center;padding:30px 20px;color:var(--muted);border-top:1px solid var(--line);display:flex;flex-direction:column;gap:12px;position:relative;isolation:isolate}
 .footer-nav{display:flex;justify-content:center;gap:16px;flex-wrap:wrap}
+.site-footer::before{
+  content:"";position:absolute;inset:0;z-index:-1;pointer-events:none;
+  background:
+    radial-gradient(2px 2px at 10px 10px,rgba(167,139,250,.14),transparent 60%) 0 0/24px 24px,
+    radial-gradient(2px 2px at 10px 10px,rgba(167,139,250,.06),transparent 60%) 12px 12px/24px 24px;
+  opacity:.85;
+  mask-image:linear-gradient(to top,black 80%,transparent 100%);
+}
+.site-footer::after{
+  content:"";position:absolute;inset:0;z-index:-1;pointer-events:none;
+  background:radial-gradient(180px 90px at var(--x,50%) 120%,rgba(167,139,250,.18),transparent 70%);
+  animation:ping-sweep 16s ease-in-out infinite;
+}
+@keyframes ping-sweep{
+  0%{--x:12%}
+  33%{--x:64%}
+  66%{--x:28%}
+  100%{--x:88%}
+}
+@media (prefers-reduced-motion:reduce){
+  .site-footer::after{animation:none}
+}
 @media (max-width:900px){
   #navToggle{display:block}
   #navMenu{position:fixed;top:60px;left:0;right:0;bottom:0;background:rgba(12,11,19,.92);backdrop-filter:blur(10px);display:flex;flex-direction:column;align-items:flex-start;gap:16px;padding:20px;transform:translateY(-100%);transition:transform .3s ease;overflow:auto;z-index:100}
@@ -80,20 +119,5 @@ html[data-theme='light'] .toggle::after{transform:translateX(18px)}
   .card:hover,.btn:hover,.card-link:hover{transform:none;box-shadow:none}
 }
 
-.faq dt{font-weight:600;margin-top:12px}.faq dd{margin:4px 0 8px 0}
+.faq h2{margin-bottom:1rem}.faq h3{margin-top:1.25rem;margin-bottom:.35rem;font-size:1.15rem}.faq p{opacity:.9}
 
-:root{
-  --accent: #a78bfa;
-}
-
-#bg-squares{
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background: #0b0b10;
-}
-
-@media (prefers-reduced-motion: reduce){
-  #bg-squares{ display:none; }
-}

--- a/theme.js
+++ b/theme.js
@@ -1,4 +1,5 @@
 // theme, nav toggle, and footer year
+// Hero background animation removed; footer pings handled in CSS only
 (function(){
   const key='theme';
   const root=document.documentElement;
@@ -34,74 +35,3 @@
   }
 })();
 
-(function(){
-  const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
-  const canvas = document.getElementById('bg-squares');
-  if (!canvas || mql.matches) return;
-
-  const ctx = canvas.getContext('2d');
-  const ACCENT = getComputedStyle(document.documentElement)
-                  .getPropertyValue('--accent').trim() || '#a78bfa';
-
-  let w, h, dpr, cols, rows, size, gap;
-  const cells = [];
-
-  function resize(){
-    dpr = Math.min(window.devicePixelRatio || 1, 2);
-    w = canvas.width  = Math.floor(innerWidth  * dpr);
-    h = canvas.height = Math.floor(innerHeight * dpr);
-    canvas.style.width  = innerWidth + 'px';
-    canvas.style.height = innerHeight + 'px';
-
-    size = 20 * dpr;
-    gap  = 10 * dpr;
-    cols = Math.ceil(w / (size + gap));
-    rows = Math.ceil(h / (size + gap));
-
-    cells.length = 0;
-    for (let y = 0; y < rows; y++){
-      for (let x = 0; x < cols; x++){
-        cells.push({ x, y, a: 0, t: Math.random() * 2000 });
-      }
-    }
-  }
-
-  function hexToRgba(hex, a){
-    const h = hex.replace('#','');
-    const full = h.length === 3 ? h.split('').map(c => c+c).join('') : h;
-    const n = parseInt(full, 16);
-    const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
-    return `rgba(${r},${g},${b},${a})`;
-  }
-
-  function frame(t){
-    ctx.clearRect(0,0,w,h);
-
-    for (const c of cells){
-      const pulse = (Math.sin((t + c.t)/1000 + (c.x*13 + c.y*7)) + 1) * 0.5;
-      c.a = c.a * 0.90 + pulse * 0.10;
-
-      if (c.a > 0.05){
-        const X = Math.floor(c.x * (size + gap));
-        const Y = Math.floor(c.y * (size + gap));
-        const S = size * 0.6;
-        ctx.fillStyle = hexToRgba(ACCENT, 0.15 * c.a);
-        ctx.fillRect(X, Y, S, S);
-      }
-    }
-    requestAnimationFrame(frame);
-  }
-
-  window.addEventListener('resize', resize, { passive: true });
-  resize();
-  requestAnimationFrame(frame);
-
-  try {
-    mql.addEventListener?.('change', e => {
-      if (e.matches) {
-        ctx.clearRect(0,0,w,h);
-        canvas.remove();
-      }
-    });
-  } catch(_) {}
-})();


### PR DESCRIPTION
## Summary
- drop hero canvas and background animation to keep hero static
- apply subtle radial gradient backdrop and add CSS-only ping sweep behind footer
- remove unused grid animation script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbec1cd348325a8ed8932ca222d62