### PR TITLE
feat: add data-driven UK mids strain menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,126 +1,165 @@
-// Simple hash-based router for Telegram Mini App
-let dataCache = null;
-
-// Load data.json once and cache it
-async function loadData() {
-  if (!dataCache) {
-    const res = await fetch('data.json');
-    dataCache = await res.json();
+const strains = [
+  {
+    id: "peanut-butter-breath",
+    name: "Peanut Butter Breath",
+    emoji: "🥜🍞😮‍💨",
+    photo: "https://placehold.co/800x500?text=Peanut+Butter+Breath",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 0, fruit: 0, gas: 0, earthy: 2, herbal: 1, spicy: 0, dessert: 2, pine: 0 },
+    dominant: "Peanut butter nuttiness with earthy backend.",
+    terp: "caryophyllene + limonene",
+    verdict: "Classic nutty cut, smooth."
+  },
+  {
+    id: "black-maple",
+    name: "Black Maple",
+    emoji: "⚫🍁🍯",
+    photo: "https://placehold.co/800x500?text=Black+Maple",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 0, fruit: 0, gas: 0, earthy: 2, herbal: 1, spicy: 0, dessert: 2, pine: 0 },
+    dominant: "Dark maple syrup with woody hashy notes.",
+    terp: "humulene + caryophyllene",
+    verdict: "Sweet + earthy, couchy vibes."
+  },
+  {
+    id: "miami-vice",
+    name: "Miami Vice",
+    emoji: "🏙️🌴🔥",
+    photo: "https://placehold.co/800x500?text=Miami+Vice",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 2, fruit: 1, gas: 2, earthy: 0, herbal: 0, spicy: 1, dessert: 0, pine: 0 },
+    dominant: "Zesty lime with tropical gas.",
+    terp: "limonene + myrcene",
+    verdict: "Bright flavour with a spicy undertone."
+  },
+  {
+    id: "dulce-de-uva",
+    name: "Dulce de Uva",
+    emoji: "🍇🥮🧃",
+    photo: "https://placehold.co/800x500?text=Dulce+de+Uva",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 0, fruit: 3, gas: 0, earthy: 0, herbal: 0, spicy: 0, dessert: 2, pine: 0 },
+    dominant: "Grape candy sweetness.",
+    terp: "linalool + ocimene",
+    verdict: "Fruity top notes, crowd pleaser."
+  },
+  {
+    id: "mandarin-peels",
+    name: "Mandarin Peels",
+    emoji: "🍊🔥🍬",
+    photo: "https://placehold.co/800x500?text=Mandarin+Peels",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 3, fruit: 1, gas: 1, earthy: 0, herbal: 0, spicy: 0, dessert: 2, pine: 0 },
+    dominant: "Tangy mandarin peel with candy finish.",
+    terp: "limonene + caryophyllene",
+    verdict: "Clean orange mids, sharp flavour."
+  },
+  {
+    id: "karamel-kut-throat",
+    name: "Karamel Kut Throat",
+    emoji: "🍮🔪",
+    photo: "https://placehold.co/800x500?text=Karamel+Kut+Throat",
+    looks: null,
+    nose: null,
+    smoothness: null,
+    flavour: { citrus: 0, fruit: 0, gas: 0, earthy: 0, herbal: 0, spicy: 0, dessert: 2, pine: 0 },
+    dominant: "Creamy caramel tones with a burnt sugar edge.",
+    terp: "linalool + caryophyllene",
+    verdict: "Sweet mids, smooth smoke."
   }
-  return dataCache;
+];
+
+const app = document.getElementById('app');
+const backBtn = document.getElementById('back-btn');
+const headerTitle = document.getElementById('header-title');
+
+function formatRating(val) {
+  return val == null ? '—/10' : `${val}/10`;
 }
 
-// Apply theme based on Telegram color scheme
-function setTheme() {
-  const isDark = window.Telegram && Telegram.WebApp && Telegram.WebApp.colorScheme === 'dark';
-  document.body.classList.toggle('dark', isDark);
+function dotBar(score) {
+  return '●'.repeat(score) + '○'.repeat(3 - score);
 }
 
-// Show or hide back buttons (HTML + Telegram)
+function renderFlavour(f) {
+  const order = [
+    ['citrus', 'Citrus'],
+    ['fruit', 'Fruit'],
+    ['gas', 'Gas'],
+    ['earthy', 'Earthy'],
+    ['herbal', 'Herbal'],
+    ['spicy', 'Spicy'],
+    ['dessert', 'Dessert'],
+    ['pine', 'Pine'],
+  ];
+  return order.map(([key, label]) => `${label} ${dotBar(f[key] || 0)}`).join(' | ');
+}
+
+function renderList() {
+  headerTitle.textContent = 'UK Mids Menu';
+  showBackButton(false);
+  app.innerHTML = '';
+  strains.forEach(strain => {
+    const btn = document.createElement('button');
+    btn.className = 'strain-btn';
+    btn.textContent = `${strain.emoji} ${strain.name}`;
+    btn.addEventListener('click', () => renderDetail(strain.id));
+    app.appendChild(btn);
+  });
+}
+
+function renderDetail(id) {
+  const strain = strains.find(s => s.id === id);
+  if (!strain) return;
+  headerTitle.textContent = strain.name;
+  showBackButton(true);
+  app.innerHTML = `
+    <div class="card">
+      <img src="${strain.photo}" alt="${strain.name}" class="photo" />
+      <h2>${strain.emoji} ${strain.name}</h2>
+      <p>Looks: ${formatRating(strain.looks)}</p>
+      <p>Nose: ${formatRating(strain.nose)}</p>
+      <p>Smoothness: ${formatRating(strain.smoothness)}</p>
+      <div class="flavour">${renderFlavour(strain.flavour)}</div>
+      <p><strong>Dominant:</strong> ${strain.dominant}</p>
+      <p><strong>Terp vibe:</strong> ${strain.terp}</p>
+      <p><strong>Verdict:</strong> ${strain.verdict}</p>
+    </div>
+  `;
+}
+
 function showBackButton(show) {
-  const btn = document.getElementById('back-btn');
-  if (show) {
-    btn.style.display = 'block';
-    if (window.Telegram && Telegram.WebApp && Telegram.WebApp.BackButton) {
-      Telegram.WebApp.BackButton.show();
-    }
-  } else {
-    btn.style.display = 'none';
-    if (window.Telegram && Telegram.WebApp && Telegram.WebApp.BackButton) {
-      Telegram.WebApp.BackButton.hide();
-    }
+  backBtn.style.display = show ? 'block' : 'none';
+  if (window.Telegram && Telegram.WebApp && Telegram.WebApp.BackButton) {
+    show ? Telegram.WebApp.BackButton.show() : Telegram.WebApp.BackButton.hide();
   }
 }
 
-// Navigate helper
-function go(hash) {
-  location.hash = hash;
-}
+backBtn.addEventListener('click', renderList);
 
-// Rendering based on route
-async function render() {
-  const hash = location.hash || '#/';
-  const parts = hash.slice(2).split('/');
-  const app = document.getElementById('app');
-
-  switch (parts[0]) {
-    case '':
-      showBackButton(false);
-      app.innerHTML = `
-        <div>
-          <button class="btn" id="menu-btn">VIEW OUR MENU</button>
-          <button class="btn" id="reviews-btn">REVIEWS</button>
-        </div>`;
-      document.getElementById('menu-btn').onclick = () => go('#/menu');
-      document.getElementById('reviews-btn').onclick = () => go('#/reviews');
-      break;
-    case 'menu':
-      if (parts[1]) {
-        showBackButton(true);
-        const slug = parts[1];
-        const data = await loadData();
-        const items = data.items.filter(i => i.categoryId === slug);
-        app.innerHTML = '';
-        items.forEach(item => {
-          const btn = document.createElement('button');
-          btn.className = 'btn';
-          btn.textContent = item.title;
-          btn.onclick = () => go(`#/item/${item.id}`);
-          app.appendChild(btn);
-        });
-      } else {
-        showBackButton(true);
-        const data = await loadData();
-        app.innerHTML = '';
-        data.categories.forEach(cat => {
-          const btn = document.createElement('button');
-          btn.className = 'btn';
-          btn.textContent = `${cat.emoji} ${cat.title}`;
-          btn.onclick = () => go(`#/menu/${cat.id}`);
-          app.appendChild(btn);
-        });
-      }
-      break;
-    case 'item':
-      showBackButton(true);
-      const id = parts[1];
-      const data = await loadData();
-      const item = data.items.find(i => i.id === id);
-      if (!item) {
-        app.innerHTML = '<p>Item not found.</p>';
-        return;
-      }
-      const pricesHtml = item.prices
-        .map(p => `<li>${p.label}: <strong>${p.amount}</strong></li>`)
-        .join('');
-      app.innerHTML = `
-        <div class="center">
-          <img src="${item.image}" alt="${item.title}" class="product-image" />
-          <h2>${item.title}</h2>
-          <p>${item.description}</p>
-          <ul class="prices">${pricesHtml}</ul>
-        </div>`;
-      break;
-    case 'reviews':
-      showBackButton(true);
-      app.innerHTML = '<p class="center">Reviews coming soon.</p>';
-      break;
-    default:
-      go('#/');
+function setTheme() {
+  if (window.Telegram && Telegram.WebApp) {
+    document.body.classList.toggle('dark', Telegram.WebApp.colorScheme === 'dark');
   }
 }
 
-window.addEventListener('hashchange', render);
-
-document.getElementById('back-btn').addEventListener('click', () => history.back());
-
-// Telegram initialization
 if (window.Telegram && Telegram.WebApp) {
   Telegram.WebApp.ready();
   Telegram.WebApp.expand();
   Telegram.WebApp.onEvent('themeChanged', setTheme);
-  Telegram.WebApp.onEvent('backButtonClicked', () => history.back());
+  Telegram.WebApp.onEvent('backButtonClicked', renderList);
 }
 
 setTheme();
-render();
+renderList();
+

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Boxed Menu</title>
+  <title>UK Mids Menu</title>
   <link rel="stylesheet" href="styles.css" />
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <script defer src="app.js"></script>
@@ -11,9 +11,9 @@
 <body>
   <header class="header">
     <button id="back-btn" class="back-btn" style="display:none" aria-label="Back">◀</button>
-    <h1 class="title">Boxed Menu</h1>
+    <h1 class="title" id="header-title">UK Mids Menu</h1>
   </header>
   <main id="app"></main>
-  <footer class="footer">Powered by Boxed Menu</footer>
+  <footer class="footer">Powered by boxxedUK</footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,24 +1,24 @@
-/* Basic reset */
+/* Reset */
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: var(--bg-color, #f5f5f5);
-  color: var(--text-color, #000);
-  min-height: 100vh;
+  background: var(--bg-color, #fff);
+  color: var(--text-color, #111);
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
 }
 
 body.dark {
   --bg-color: #1c1c1e;
   --text-color: #fff;
+  --card-bg: #2c2c2e;
   --button-bg: #2c2c2e;
-  --button-text: #fff;
 }
 
 body:not(.dark) {
-  --button-bg: #e5e5ea;
-  --button-text: #000;
+  --card-bg: #f2f2f7;
+  --button-bg: #f2f2f7;
 }
 
 .header {
@@ -29,13 +29,14 @@ body:not(.dark) {
 
 .title {
   font-size: 1.5rem;
+  font-weight: bold;
 }
 
 .back-btn {
   position: absolute;
   left: 1rem;
   top: 1rem;
-  background: transparent;
+  background: none;
   border: none;
   font-size: 1.2rem;
 }
@@ -45,47 +46,54 @@ main {
   padding: 1rem;
 }
 
-.footer {
-  text-align: center;
-  padding: 0.5rem;
-  font-size: 0.8rem;
-  color: #666;
-  position: sticky;
-  bottom: 0;
-  background: var(--bg-color, #f5f5f5);
-}
-
-.btn {
+.strain-btn {
   width: 100%;
-  padding: 1rem;
-  margin-bottom: 0.75rem;
+  padding: 16px;
+  margin-bottom: 1rem;
   background: var(--button-bg);
-  color: var(--button-text);
   border: none;
-  border-radius: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   font-size: 1rem;
 }
 
-.btn:active {
+.strain-btn:active {
   opacity: 0.7;
 }
 
-.product-image {
+.card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.photo {
   width: 100%;
-  border-radius: 1rem;
+  border-radius: 8px;
   margin-bottom: 1rem;
 }
 
-.prices {
-  list-style: none;
-  margin-top: 1rem;
+.card h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
 }
 
-.prices li {
-  margin-bottom: 0.25rem;
-  font-weight: bold;
+.card p {
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
 }
 
-.center {
+.flavour {
+  margin: 0.5rem 0;
+}
+
+.footer {
   text-align: center;
+  padding: 0.5rem 0;
+  font-size: 0.8rem;
+  color: #555;
+  margin-top: auto;
 }
+
+


### PR DESCRIPTION
## Summary
- Replace static page with data-driven UK mids menu designed for Telegram WebApp
- Add six strain profiles with flavour buckets and detail views
- Restyle layout with rounded buttons and cards; footer credits boxxedUK

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b472e4ae108325b21f26bb3ea8f295