### PR TITLE
Add SPA menu navigation

### DIFF
--- a/data/menu-config.js
+++ b/data/menu-config.js
@@ -1,0 +1,63 @@
+export const categories = [
+  { key: 'uk_tops', label: '🇬🇧 UK TOPS' },
+  { key: 'uk_mids', label: '🇬🇧 UK MIDS' },
+  { key: 'cali_packs', label: '🇺🇸 CALI PACKS' },
+  { key: 'extracts', label: '🍯 EXTRACTS' },
+  { key: 'hash', label: '#️⃣ HASH' },
+  { key: 'edibles', label: '🍫 EDIBLES' },
+  { key: 'how_to_order', label: '📃 HOW TO ORDER', type: 'info' },
+  { key: 'postal_info', label: '📮 POSTAL INFO', type: 'info' },
+];
+
+export const items = {
+  uk_tops: [
+    { name: 'Coming soon…', disabled: true }
+  ],
+  cali_packs: [
+    { name: 'Coming soon…', disabled: true }
+  ],
+  extracts: [
+    {
+      id: 'gas-og',
+      name: 'GAS OG',
+      emoji: '⛽️🍯',
+      photo: 'https://placehold.co/800x500?text=GAS+OG',
+      looks: null,
+      nose: null,
+      smoothness: null,
+      flavour: { citrus: 0, fruit: 0, gas: 0, earthy: 0, herbal: 0, spicy: 0, dessert: 0, pine: 0 },
+      dominant: '',
+      terp: '',
+      verdict: ''
+    }
+  ],
+  hash: [
+    {
+      id: 'cali-mouse-hash',
+      name: 'CALI MOUSE HASH',
+      emoji: '🔥⛽️🍫',
+      photo: 'https://placehold.co/800x500?text=CALI+MOUSE+HASH',
+      looks: null,
+      nose: null,
+      smoothness: null,
+      flavour: { citrus: 0, fruit: 0, gas: 0, earthy: 0, herbal: 0, spicy: 0, dessert: 0, pine: 0 },
+      dominant: '',
+      terp: '',
+      verdict: ''
+    }
+  ],
+  edibles: [
+    { name: 'Coming soon…', disabled: true }
+  ]
+};
+
+export const infoPages = {
+  how_to_order: `<p>Message <strong>@TEATIME110</strong> with:<br>• Strain name(s)<br>• Quantity (g)<br>• Postcode</p>
+   <p><strong>Payment:</strong> Bank transfer or <em>PayPal Friends & Family</em>.</p>
+   <p>We’ll confirm total + dispatch window and send your reference.</p>`,
+  postal_info: `<p><strong>Dispatch:</strong> Orders before <strong>11:00</strong> are eligible for <em>same-day dispatch</em>. Orders after 11:00 ship the <em>next day</em>.</p>
+   <p><strong>Services:</strong> Royal Mail First Class or Tracked 24 (next-day).</p>
+   <p><strong>Tracking:</strong> Provided for Tracked 24. First Class is untracked.</p>
+   <p><strong>Packaging:</strong> Discreet, smell-proof, letterbox-friendly where possible.</p>
+   <p><strong>Notes:</strong> Weekend/Bank Holiday dispatch may vary; you’ll receive an ETA in chat.</p>`
+};

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>UK Mids Menu</title>
-  <link rel="stylesheet" href="styles.css" />
-  <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script defer src="app.js"></script>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <script type="module" src="app.js"></script>
 </head>
 <body>
   <header class="header">

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,0 +1,18 @@
+let renderFn;
+let stack = [];
+
+export function init(fn, initialRoute) {
+  renderFn = fn;
+  stack = [initialRoute];
+  renderFn(initialRoute);
+}
+
+export function navigate(route) {
+  stack.push(route);
+  renderFn(route);
+}
+
+export function back() {
+  if (stack.length > 1) stack.pop();
+  renderFn(stack[stack.length - 1]);
+}


### PR DESCRIPTION
## Summary
- introduce router and menu config to support multi-category SPA navigation
- add Our Menu and Reviews entry buttons to landing screen
- seed menu categories, placeholder items, extracts/hash details, and info pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b494b982288325b6f7e45320d1ab0f