### PR TITLE
Add video preview for Peanut Butter Breath strain

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const strains = [
     name: "Peanut Butter Breath",
     emoji: "🥜🍞😮‍💨",
     photo: "https://placehold.co/800x500?text=Peanut+Butter+Breath",
+    video: "/videos/peanut-butter-breath.mp4",
     looks: null,
     nose: null,
     smoothness: null,
@@ -205,7 +206,12 @@ function renderDetail(id) {
   showBackButton(true);
   app.innerHTML = `
     <div class="card">
-      <img src="${strain.photo}" alt="${strain.name}" class="photo" />
+      ${strain.video ? `
+        <video autoplay loop muted playsinline class="photo">
+          <source src="${strain.video}" type="video/mp4" />
+          <img src="${strain.photo}" alt="${strain.name}" class="photo" />
+        </video>
+      ` : `<img src="${strain.photo}" alt="${strain.name}" class="photo" />`}
       <h2>${strain.emoji} ${strain.name}</h2>
       <p>Looks: ${formatRating(strain.looks)}</p>
       <p>Nose: ${formatRating(strain.nose)}</p>


### PR DESCRIPTION
## Summary
- display Peanut Butter Breath strain using autoplaying, looping video with muted inline playback
- gracefully fall back to the existing placeholder image if the video cannot load

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b56b9e05888325acd107d65c005bcb