### PR TITLE
UI polish for strain profiles and menu placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,7 +117,10 @@ function renderFlavour(f) {
     ['dessert', 'Dessert'],
     ['pine', 'Pine'],
   ];
-  return order.map(([key, label]) => `${label} ${dotBar(f[key] || 0)}`).join(' | ');
+  return order
+    .filter(([key]) => (f[key] || 0) > 0)
+    .map(([key, label]) => `${label} ${dotBar(f[key])}`)
+    .join(' | ');
 }
 
 function renderHome() {
@@ -232,6 +235,7 @@ function renderDetail(id) {
       <p><strong>Dominant:</strong> ${strain.dominant}</p>
       <p><strong>Terp vibe:</strong> ${strain.terp}</p>
       <p><strong>Verdict:</strong> ${strain.verdict}</p>
+      <p style="margin-top:12px;"><strong>Weights 💸</strong><br>£45 – 3.5g<br>£80 – 7g<br>£120 – 14g<br>DM for Zs and up</p>
     </div>
   `;
 }

--- a/data/menu-config.js
+++ b/data/menu-config.js
@@ -11,10 +11,10 @@ export const categories = [
 
 export const items = {
   uk_tops: [
-    { name: 'Coming soon…', disabled: true }
+    { name: 'Restocking…', disabled: true }
   ],
   cali_packs: [
-    { name: 'Coming soon…', disabled: true }
+    { name: 'Restocking…', disabled: true }
   ],
   extracts: [
     {
@@ -47,7 +47,7 @@ export const items = {
     }
   ],
   edibles: [
-    { name: 'Coming soon…', disabled: true }
+    { name: 'Restocking…', disabled: true }
   ]
 };
 

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,7 @@ main {
   border-radius: 12px;
   background: #e9eaee;
   object-fit: cover;
+  margin-bottom: 16px;
 }
 
 


### PR DESCRIPTION
## Summary
- add margin-bottom spacing to strain videos for consistent breathing room
- replace "Coming soon" placeholder labels with "Restocking" across menu categories
- show only non-zero flavour categories and add standardized weights block on strain detail pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b589a1684c8325bd0f302b5a9a1aac