### PR TITLE
Add Back to Menu on UK Mids and emoji labels on landing buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,20 +130,22 @@ function renderHome() {
 
   const menuBtn = document.createElement('button');
   menuBtn.className = 'strain-btn';
-  menuBtn.textContent = 'OUR MENU';
+  menuBtn.textContent = '🌿 OUR MENU 🌿';
   menuBtn.addEventListener('click', () => navigate('menu'));
   app.appendChild(menuBtn);
 
   const reviewsBtn = document.createElement('button');
   reviewsBtn.className = 'strain-btn';
-  reviewsBtn.textContent = 'REVIEWS';
+  reviewsBtn.textContent = '📈 REVIEWS 📈';
   reviewsBtn.addEventListener('click', () => navigate('reviews'));
   app.appendChild(reviewsBtn);
 }
 
 function renderList() {
   headerTitle.textContent = 'UK Mids Menu';
-  showBackButton(false);
+  const goHome = () => navigate('home');
+  showBackButton(true, goHome);
+  backBtn.textContent = '◀︎';
   app.innerHTML = '';
 
   strains.forEach(strain => {
@@ -153,6 +155,21 @@ function renderList() {
     btn.addEventListener('click', () => navigate(`detail:${strain.id}`));
     app.appendChild(btn);
   });
+
+  const backHome = document.createElement('div');
+  backHome.className = 'strain-btn';
+  backHome.setAttribute('role', 'button');
+  backHome.tabIndex = 0;
+  backHome.textContent = '⬅️ Back to Menu';
+  backHome.style.marginTop = '16px';
+  backHome.addEventListener('click', goHome);
+  backHome.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      goHome();
+    }
+  });
+  app.appendChild(backHome);
 }
 
 function renderMenu() {
@@ -240,14 +257,14 @@ function renderDetail(id) {
   `;
 }
 
-function showBackButton(show) {
+function showBackButton(show, handler = back) {
   backBtn.style.display = show ? 'block' : 'none';
+  backBtn.onclick = handler;
   if (window.Telegram && Telegram.WebApp && Telegram.WebApp.BackButton) {
+    Telegram.WebApp.BackButton.onClick(handler);
     show ? Telegram.WebApp.BackButton.show() : Telegram.WebApp.BackButton.hide();
   }
 }
-
-backBtn.addEventListener('click', back);
 
 function setTheme() {
   if (window.Telegram && Telegram.WebApp) {
@@ -259,7 +276,6 @@ if (window.Telegram && Telegram.WebApp) {
   Telegram.WebApp.ready();
   Telegram.WebApp.expand();
   Telegram.WebApp.onEvent('themeChanged', setTheme);
-  Telegram.WebApp.onEvent('backButtonClicked', back);
 }
 
 function renderRoute(route) {

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
     <script type="module" src="app.js"></script>
 </head>
 <body>
-  <header class="header">
-    <button id="back-btn" class="back-btn" style="display:none" aria-label="Back">◀</button>
-    <h1 class="title" id="header-title">UK Mids Menu</h1>
-  </header>
+    <header class="header">
+      <button id="back-btn" class="back-btn" style="display:none" aria-label="Back">◀︎</button>
+      <h1 class="title" id="header-title">UK Mids Menu</h1>
+    </header>
   <main id="app"></main>
   <footer class="footer">Powered by boxxedUK</footer>
 </body>


### PR DESCRIPTION
## Summary
- add header and footer back-to-menu controls on UK Mids list
- decorate landing buttons with plant and chart emojis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b58bc93cb88325930c2a924b7800fa